### PR TITLE
Allow user to configure subshell

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,17 @@ See https://godoc.org/github.com/robfig/cron for the complete interval / schedul
 
 Minicron will prevent multiple command executions if a command is still running. Stdout / Stderr output is combined for all commands.
 
-Commands are exec'd on shell `/bin/sh`, you can configure shell from environment variable `SHELL`
+Note: Commands are not exec'd in a subshell by default. But subshell can be configured using `MINICRON_SHELL` environment variable.
 
 ## Running in Docker
 
     docker pull networkteamcom/minicron
+
+    # Without subshell
     docker run -it --rm networkteamcom/minicron -v -c "test" "@every 5s" "echo Test"
+
+    # With subshell
+    docker run -it --rm -e MINICRON_SHELL networkteamcom/minicron -v -c "test" "@every 5s" "echo Test && echo Done"
+
 
 But most of the time you might want to use this in a [multi-stage build](https://docs.docker.com/engine/userguide/eng-image/multistage-build/#use-multi-stage-builds) to copy the static binary to another image.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See https://godoc.org/github.com/robfig/cron for the complete interval / schedul
 
 Minicron will prevent multiple command executions if a command is still running. Stdout / Stderr output is combined for all commands.
 
-Note: Commands are exec'd without a subshell.
+Commands are exec'd on shell `/bin/sh`, you can configure shell from environment variable `SHELL`
 
 ## Running in Docker
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Note: Commands are not exec'd in a subshell by default. But subshell can be conf
     docker run -it --rm networkteamcom/minicron -v -c "test" "@every 5s" "echo Test"
 
     # With subshell
-    docker run -it --rm -e MINICRON_SHELL networkteamcom/minicron -v -c "test" "@every 5s" "echo Test && echo Done"
+    docker run -it --rm -e MINICRON_SHELL=/bin/sh networkteamcom/minicron -v -c "test" "@every 5s" "echo Test && echo Done"
 
 
 But most of the time you might want to use this in a [multi-stage build](https://docs.docker.com/engine/userguide/eng-image/multistage-build/#use-multi-stage-builds) to copy the static binary to another image.

--- a/main.go
+++ b/main.go
@@ -78,11 +78,12 @@ func (c *cmdJob) Run() {
 			c.log("Running", ansiWhite(c.cmd))
 		}
 
+		p = nil
 		if useShell {
-			p := exec.Command(shell, "-c", c.cmd)
+			p = exec.Command(shell, "-c", c.cmd)
 		} else {
 			cmdAndArgs := strings.Split(c.cmd, " ")
-			p := exec.Command(cmdAndArgs[0], cmdAndArgs[1:]...)
+			p = exec.Command(cmdAndArgs[0], cmdAndArgs[1:]...)
 		}
 
 		logStreamerOut := logstreamer.NewLogstreamer(c.logger, "stdout", false)

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func (c *cmdJob) Run() {
 			c.log("Running", ansiWhite(c.cmd))
 		}
 
-		var p exec.Cmd
+		var p *exec.Cmd
 		if useShell {
 			p = exec.Command(shell, "-c", c.cmd)
 		} else {

--- a/main.go
+++ b/main.go
@@ -13,14 +13,16 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/kvz/logstreamer"
 	"github.com/mgutz/ansi"
 	"github.com/robfig/cron"
 )
 
-const Shell = "/bin/sh"
+shell, ok := os.LookupEnv(key)
+if !ok {
+	shell = "/bin/sh"
+}
 
 var (
 	verbose       = false

--- a/main.go
+++ b/main.go
@@ -19,17 +19,17 @@ import (
 	"github.com/robfig/cron"
 )
 
-shell, ok := os.LookupEnv(key)
-if !ok {
-	shell = "/bin/sh"
-}
-
 var (
 	verbose       = false
 	jobIDSequence = 1
+	shell = "/bin/sh"
 )
 
 func main() {
+	shellEnv, ok := os.LookupEnv(key)
+	if ok {
+		shell = shellEnv
+	}
 	c := cron.New()
 	addJobs(c, os.Args)
 	c.Run()
@@ -78,7 +78,7 @@ func (c *cmdJob) Run() {
 		if verbose {
 			c.log("Running", ansiWhite(c.cmd))
 		}
-		p := exec.Command(Shell, "-c", c.cmd)
+		p := exec.Command(shell, "-c", c.cmd)
 
 		logStreamerOut := logstreamer.NewLogstreamer(c.logger, "stdout", false)
 		defer logStreamerOut.Close()

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ import (
 var (
 	verbose       = false
 	jobIDSequence = 1
-	useShell = false
+	useShell bool
 	shell string
 )
 

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ var (
 )
 
 func main() {
-	shell, useShell := os.LookupEnv("MINICRON_SHELL")
+	shell, useShell = os.LookupEnv("MINICRON_SHELL")
 	c := cron.New()
 	addJobs(c, os.Args)
 	c.Run()

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ import (
 	"github.com/robfig/cron"
 )
 
+const Shell = "/bin/sh"
+
 var (
 	verbose       = false
 	jobIDSequence = 1
@@ -74,8 +76,7 @@ func (c *cmdJob) Run() {
 		if verbose {
 			c.log("Running", ansiWhite(c.cmd))
 		}
-		cmdAndArgs := strings.Split(c.cmd, " ")
-		p := exec.Command(cmdAndArgs[0], cmdAndArgs[1:]...)
+		p := exec.Command(Shell, "-c", c.cmd)
 
 		logStreamerOut := logstreamer.NewLogstreamer(c.logger, "stdout", false)
 		defer logStreamerOut.Close()

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ var (
 )
 
 func main() {
-	shellEnv, ok := os.LookupEnv(key)
+	shellEnv, ok := os.LookupEnv("SHELL")
 	if ok {
 		shell = shellEnv
 	}

--- a/main.go
+++ b/main.go
@@ -23,8 +23,8 @@ import (
 var (
 	verbose       = false
 	jobIDSequence = 1
-	shell = "/bin/sh"
 	useShell = false
+	shell string
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func (c *cmdJob) Run() {
 			c.log("Running", ansiWhite(c.cmd))
 		}
 
-		p = nil
+		var p exec.Cmd
 		if useShell {
 			p = exec.Command(shell, "-c", c.cmd)
 		} else {


### PR DESCRIPTION
Allow user to use subshell by providing `MINICRON_SHELL` env variable

If `MINICRON_SHELL` env varibale is not set, it will work as before

#1 